### PR TITLE
Allow constructor dependency injection on a HATEOAS class

### DIFF
--- a/src/HateoasManager.php
+++ b/src/HateoasManager.php
@@ -36,8 +36,11 @@ class HateoasManager
     protected function getLinksFrom(string $class, $arguments = [])
     {
         $links = collect(get_class_methods($class))
+            ->filter(function ($method) {
+                return ! Str::startsWith($method, '__');
+            })
             ->map(function ($method) use ($class, $arguments) {
-                $link = call_user_func_array([new $class, $method], $arguments);
+                $link = call_user_func_array([app($class), $method], $arguments);
 
                 if ($link === null || ! $link instanceof Link) {
                     return;
@@ -49,7 +52,8 @@ class HateoasManager
 
                 return $link->as(Str::snake($method));
             })
-            ->filter();
+            ->filter()
+            ->values();
 
         return LinkCollection::make($links);
     }

--- a/tests/App/Hateoas/MessageHateoasWithConstructorDependencyInjection.php
+++ b/tests/App/Hateoas/MessageHateoasWithConstructorDependencyInjection.php
@@ -2,9 +2,9 @@
 
 namespace GDebrauwer\Hateoas\Tests\App\Hateoas;
 
+use Illuminate\Cache\CacheManager;
 use GDebrauwer\Hateoas\Tests\App\Message;
 use GDebrauwer\Hateoas\Traits\CreatesLinks;
-use Illuminate\Cache\CacheManager;
 
 class MessageHateoasWithConstructorDependencyInjection
 {

--- a/tests/App/Hateoas/MessageHateoasWithConstructorDependencyInjection.php
+++ b/tests/App/Hateoas/MessageHateoasWithConstructorDependencyInjection.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace GDebrauwer\Hateoas\Tests\App\Hateoas;
+
+use GDebrauwer\Hateoas\Tests\App\Message;
+use GDebrauwer\Hateoas\Traits\CreatesLinks;
+use Illuminate\Cache\CacheManager;
+
+class MessageHateoasWithConstructorDependencyInjection
+{
+    use CreatesLinks;
+
+    /**
+     * @var \Illuminate\Cache\CacheManager
+     */
+    protected $cache;
+
+    /**
+     * Create a new HATEOAS instance.
+     *
+     * @param \Illuminate\Cache\CacheManager  $cache
+     */
+    public function __construct(CacheManager $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Get the HATEOAS link to view the message.
+     *
+     * @param \App\Message $message
+     *
+     * @return null|\GDebrauwer\Hateoas\Link
+     */
+    public function self(Message $message)
+    {
+        return $this->link('message.show', ['message' => $message->id]);
+    }
+}

--- a/tests/HateoasManagerTest.php
+++ b/tests/HateoasManagerTest.php
@@ -12,9 +12,9 @@ use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasReturningNoLinks;
 use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasReturningNonLinks;
 use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasWithExtraParameters;
 use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasReturningNotAllLinks;
-use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasWithConstructorDependencyInjection;
 use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasWithSpecificNamedLink;
 use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasWithNonSnakeCaseMethods;
+use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasWithConstructorDependencyInjection;
 
 class HateoasManagerTest extends TestCase
 {

--- a/tests/HateoasManagerTest.php
+++ b/tests/HateoasManagerTest.php
@@ -12,6 +12,7 @@ use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasReturningNoLinks;
 use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasReturningNonLinks;
 use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasWithExtraParameters;
 use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasReturningNotAllLinks;
+use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasWithConstructorDependencyInjection;
 use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasWithSpecificNamedLink;
 use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoasWithNonSnakeCaseMethods;
 
@@ -181,6 +182,22 @@ class HateoasManagerTest extends TestCase
         });
 
         $this->assertEquals([], $this->manager->generate(MessageHateoasWithSpecificNamedLink::class, [Message::make(['id' => 1])]));
+    }
+
+    /** @test */
+    public function it_generates_a_link_collection_even_if_hateoas_class_constructor_uses_dependency_injection()
+    {
+        $this->mock(DefaultFormatter::class, function ($mock) {
+            $mock->shouldReceive('format')
+                ->once()
+                ->withArgs(function ($links) {
+                    return $links->count() === 1
+                        && $this->assertEqualLinks(Link::make('message.show', ['message' => 1])->as('self'), $links[0]);
+                })
+                ->andReturn([]);
+        });
+
+        $this->assertEquals([], $this->manager->generate(MessageHateoasWithConstructorDependencyInjection::class, [Message::make(['id' => 1])]));
     }
 
     /** @test */


### PR DESCRIPTION
When all methods of HATEOAS class are fetched, all default PHP class methods, including the constructor, are now ignored. Creating instances of HATEOAS classes happens with the `app($class)` helper instead of `new $class`, to allow dependency injection in the constructor.