### PR TITLE
Update 'links' method of HasLinks trait to make first parameter optional

### DIFF
--- a/src/Traits/HasLinks.php
+++ b/src/Traits/HasLinks.php
@@ -9,13 +9,18 @@ trait HasLinks
     /**
      * Generate JSON based on the (provided) HATEOAS class.
      *
-     * @param string $class
+     * @param null|array|string $class
      * @param array $arguments
      *
      * @return array
      */
-    public function links(string $class = null, $arguments = [])
+    public function links($class = null, $arguments = [])
     {
+        if (is_array($class)) {
+            $arguments = $class;
+            $class = null;
+        }
+
         return Hateoas::generate(
             $class ?? get_class($this->resource),
             array_merge([$this->resource], $arguments)

--- a/tests/App/Http/Resources/MessageResourceWithExtraArgumentsViaClassParameter.php
+++ b/tests/App/Http/Resources/MessageResourceWithExtraArgumentsViaClassParameter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace GDebrauwer\Hateoas\Tests\App\Http\Resources;
+
+use GDebrauwer\Hateoas\Traits\HasLinks;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class MessageResourceWithExtraArgumentsViaClassParameter extends JsonResource
+{
+    use HasLinks;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'text' => $this->text,
+            '_links' => $this->links(['abc', 123]),
+        ];
+    }
+}

--- a/tests/HasLinksTest.php
+++ b/tests/HasLinksTest.php
@@ -8,6 +8,7 @@ use GDebrauwer\Hateoas\Tests\App\Hateoas\MessageHateoas;
 use GDebrauwer\Hateoas\Tests\App\Http\Resources\MessageResource;
 use GDebrauwer\Hateoas\Tests\App\Http\Resources\MessageResourceWithExtraArguments;
 use GDebrauwer\Hateoas\Tests\App\Http\Resources\MessageResourceWithExplicitHateoasClass;
+use GDebrauwer\Hateoas\Tests\App\Http\Resources\MessageResourceWithExtraArgumentsViaClassParameter;
 
 class HasLinksTest extends TestCase
 {
@@ -21,7 +22,7 @@ class HasLinksTest extends TestCase
      *
      * @return void
      */
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -59,5 +60,16 @@ class HasLinksTest extends TestCase
             ->andReturn([]);
 
         (new MessageResourceWithExtraArguments($this->message))->toArray(null);
+    }
+
+    /** @test */
+    public function it_calls_hateaos_generate_method_with_extra_arguments_provided_via_class_parameter()
+    {
+        Hateoas::shouldReceive('generate')
+            ->once()
+            ->with(Message::class, [$this->message, 'abc', 123])
+            ->andReturn([]);
+
+        (new MessageResourceWithExtraArgumentsViaClassParameter($this->message))->toArray(null);
     }
 }


### PR DESCRIPTION
If you don't have to provide a specific hateoas classname, you can pass your extra arguments array to the first parameter of the 'links' method:

```php
// Before:
$this->links(null, ['abc', 123]);

// After:
$this->links(['abc', 123]);
```